### PR TITLE
Fix DROP index vs constraint issue (#38)

### DIFF
--- a/testapp/migrations/0002_test_unique_nullable_part1.py
+++ b/testapp/migrations/0002_test_unique_nullable_part1.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('testapp', '0001_initial'),
+    ]
+
+    operations = [
+        # Create with a field that is unique *and* nullable so it is implemented with a filtered unique index.
+        migrations.CreateModel(
+            name='TestUniqueNullableModel',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('test_field', models.CharField(max_length=100, null=True, unique=True)),
+            ],
+        ),
+    ]

--- a/testapp/migrations/0003_test_unique_nullable_part2.py
+++ b/testapp/migrations/0003_test_unique_nullable_part2.py
@@ -1,0 +1,18 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('testapp', '0002_test_unique_nullable_part1'),
+    ]
+
+    operations = [
+        # Now remove the null=True to check this transition is correctly handled.
+        migrations.AlterField(
+            model_name='testuniquenullablemodel',
+            name='test_field',
+            field=models.CharField(default='', max_length=100, unique=True),
+            preserve_default=False,
+        ),
+    ]

--- a/testapp/models.py
+++ b/testapp/models.py
@@ -41,3 +41,10 @@ class UUIDModel(models.Model):
 
     def __str__(self):
         return self.pk
+
+
+class TestUniqueNullableModel(models.Model):
+    # This field started off as unique=True *and* null=True so it is implemented with a filtered unique index
+    # Then it is made non-nullable by a subsequent migration, to check this is correctly handled (the index
+    # should be dropped, then a normal unique constraint should be added, now that the column is not nullable)
+    test_field = models.CharField(max_length=100, unique=True)


### PR DESCRIPTION
The return value from `_constraint_names` includes unique indexes even if these are not actual constraints.

Therefore trying to drop these using `sql_delete_unique` ("ALTER TABLE ... DROP CONSTRAINT ...") will fail because it is an index, not a constraint.

Instead explicitly deal with unique indexes separately.

With this patch I can no longer repro the issue at #38