### PR TITLE
Added failover_partner option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -178,13 +178,18 @@ Dictionary. Current available keys are:
 
 -  connection_retry_backoff_time
 
-   Integer. Sets the back off time in seconds for reries of
+   Integer. Sets the back off time in seconds for retries of
    the database connection process. Default value is ``5``.
 
 -  query_timeout
 
    Integer. Sets the timeout in seconds for the database query.
    Default value is ``0`` which disables the timeout.
+
+-  failover_partner
+
+   String. Same as HOST but for failover partner.
+   Default is not specified which disable the failover partner.
 
 backend-specific settings
 ~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Hello dear folks! Thanks for maintaining this project!

In our production setup we are using two MS SQL servers - one main and one failover.
Here is an implementation of the ability to specify such failover host (aka failover partner) which would be used during connection initiation if main server is currently down or unavailable.