### PR TITLE
Added AAD authentication for Azure SQL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ tests/local_settings.py
 # Virtual Env
 /venv/
 .idea/
+
+# VS Code
+.vscode/

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,9 @@ setup(
     packages=find_packages(),
     install_requires=[
         'pyodbc>=3.0',
+        'msal>=1.2.0'
     ],
     package_data={'sql_server.pyodbc': ['regex_clr.dll']},
     classifiers=CLASSIFIERS,
-    keywords='django',
+    keywords='AZURE django',
 )

--- a/sql_server/pyodbc/aad_auth.py
+++ b/sql_server/pyodbc/aad_auth.py
@@ -1,0 +1,123 @@
+import struct
+import msal
+
+
+class AADAuthAccessTokenRetrievalError(Exception):
+    pass
+
+
+class AADAuth(object):
+    """
+    Defines the Azure Active Directory authentication class.
+    """
+
+    @classmethod
+    def _get_access_token(cls, authority, client_id, scopes, secret):
+        """
+        Retrieves the application's access token through AAD.
+
+        Parameters½
+        ----------
+        authority : str
+            The AAD authority url which is of the form
+            `https://login.microsoftonline.com/<TENANT_ID>`.
+        client_id : str
+            The client identifier used to authenticate.
+        scopest : list
+            The list of scopes to use to authenticate. For database
+            connections we should be using`["https://database.windows.net//.default"]`.
+        secret : str
+            The secret to authenticate with.
+
+        Returns
+        -------
+        str
+            The retrieved access token if present; otherwise, `None`.
+        """
+        app = msal.ConfidentialClientApplication(
+            client_id, authority=authority, client_credential=secret
+        )
+        result = app.acquire_token_silent(scopes, account=None)
+        if not result:
+            result = app.acquire_token_for_client(scopes=scopes)
+        access_token = result.get("access_token", None)
+        return access_token
+
+    @classmethod
+    def _struct_from_access_token(cls, access_token):
+        """
+        Create a structure from the access token.
+
+        Parameters
+        ----------
+        access_token : str
+            The access token to convert.
+
+        Returns
+        -------
+        str
+            The expanded token structure required.
+        """
+        token_bytes = bytes(access_token, "UTF-8")
+        expanded_token = b""
+        for i in token_bytes:
+            expanded_token += bytes({i})
+            expanded_token += bytes(1)
+        token_struct = struct.pack("=i", len(expanded_token)) + expanded_token
+        return token_struct
+
+    @classmethod
+    def _construct_attrs_before_using_access_token(cls, access_token):
+        """
+        Constructs the `attrs_before` `pyodbc` parameter from an access token.
+
+        Parameters
+        ----------
+        access_token : str
+            The access token to construct the parameter with.
+
+        Returns
+        -------
+        dict
+            The `attrs_before` dictionary of values that will be used to authenticate
+            using the access token.
+        """
+        SQL_COPT_SS_ACCESS_TOKEN = 1256
+        token_struct = cls._struct_from_access_token(access_token)
+        attrs_before = {SQL_COPT_SS_ACCESS_TOKEN: token_struct}
+        return attrs_before
+
+    @classmethod
+    def create_attrs_before_with_access_token(cls, config):
+        """
+        Creates the `attrs_before` `pyodbc` parameter by first retrieving an AAD 
+        access token for the application and then using it to build the parameter.
+
+        Parameters
+        ----------
+        config : dict
+            The dictionary of values needed to retrieve an application access token.
+            Should contain `tenant_id`, `client_id` and `secret`.
+
+        Returns
+        -------
+        dict
+            The `attrs_before` dictionary of values that will be used to authenticate
+            using the access token.
+
+        Raises
+        ------
+        AADAuthAccessTokenRetrievalError
+            When unable to retrieve a valid access token, the exception is raised.
+        """
+        tenant_id = config["tenant_id"]
+        client_id = config["client_id"]
+        secret = config["secret"]
+        authority = "https://login.microsoftonline.com/" + tenant_id
+        scopes = ["https://database.windows.net//.default"]
+        access_token = cls._get_access_token(authority, client_id, scopes, secret)
+        if not access_token:
+            raise AADAuthAccessTokenRetrievalError("Unable to retrieve access token!")
+
+        attrs_before = cls._construct_attrs_before_using_access_token(access_token)
+        return attrs_before

--- a/sql_server/pyodbc/base.py
+++ b/sql_server/pyodbc/base.py
@@ -34,6 +34,7 @@ from .features import DatabaseFeatures # noqa
 from .introspection import DatabaseIntrospection # noqa
 from .operations import DatabaseOperations # noqa
 from .schema import DatabaseSchemaEditor # noqa
+from .aad_auth import AADAuth
 
 EDITION_AZURE_SQL_DB = 5
 
@@ -241,6 +242,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         user = conn_params.get('USER', None)
         password = conn_params.get('PASSWORD', None)
         port = conn_params.get('PORT', None)
+        aad_auth = conn_params.get('AAD-AUTH', None)
 
         options = conn_params.get('OPTIONS', {})
         driver = options.get('driver', 'ODBC Driver 13 for SQL Server')
@@ -276,7 +278,12 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             else:
                 cstr_parts['SERVERNAME'] = host
 
-        if user:
+        attrs_before = {}
+        if aad_auth:
+            # For AAD auth using access token we need to set the `attrs_before`
+            # parameter with the retrieved access token struct.
+            attrs_before = AADAuth.create_attrs_before_with_access_token(aad_auth)
+        elif user:
             cstr_parts['UID'] = user
             cstr_parts['PWD'] = password
         else:
@@ -311,7 +318,8 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             try:
                 conn = Database.connect(connstr,
                                         unicode_results=unicode_results,
-                                        timeout=timeout)
+                                        timeout=timeout,
+                                        attrs_before=attrs_before)
             except Exception as e:
                 for error_number in self._transient_error_numbers:
                     if error_number in e.args[1]:


### PR DESCRIPTION
Added functionality from [django-azure-sql-backend](https://github.com/langholz/django-azure-sql-backend) for Azure SQL authentication using AAD. The other fork only supports Django 2.1, so implementing the additional AAD functionality is simple here. Readme updated with instructions, also taken from the same fork. 