### PR TITLE
Fix host_is_server URL and expand docs in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -149,10 +149,12 @@ Dictionary. Current available keys are:
    definition present in the ``freetds.conf`` FreeTDS configuration file
    instead of a hostname or an IP address.
 
-   But if this option is present and it's value is ``True``, this
-   special behavior is turned off.
+   But if this option is present and its value is ``True``, this
+   special behavior is turned off. Instead, connections to the database
+   server will be established using ``HOST`` and ``PORT`` options, without
+   requiring ``freetds.conf`` to be configured.
 
-   See http://www.freetds.org/userguide/dsnless.htm for more information.
+   See https://www.freetds.org/userguide/dsnless.html for more information.
 
 -  unicode_results
 


### PR DESCRIPTION
The URL mentioned under `host_is_server` was broken; this fixes that URL.  Also, this expands the docs for this option - explaining which settings will be used to connect if `host_is_server` is enabled.