### PR TITLE
Add pyodbc pre-requisites to readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,7 @@ Installation
 ------------
 
 1. Install pyodbc and Django
+  - `pyodbc has some pre-requisites <https://github.com/mkleehammer/pyodbc/wiki/Install>`__
 
 2. Install django-mssql-backend ::
 


### PR DESCRIPTION
pyodbc requires some additional c++ dependencies that may need to be installed before django-mssql-backend can be successfully installed by pip.

Install instructions are listed on the pyodbc repo, it's probably best to link to them, instead of copying them in case they are changed / updated at a later date. https://github.com/mkleehammer/pyodbc/wiki/Install