### PR TITLE
Update features.py

### DIFF
--- a/sql_server/pyodbc/features.py
+++ b/sql_server/pyodbc/features.py
@@ -27,6 +27,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     supports_deferrable_unique_constraints = False
     supports_ignore_conflicts = False
     supports_index_on_text_field = False
+    supports_over_clause = True
     supports_paramstyle_pyformat = False
     supports_regex_backreferencing = True
     supports_sequence_reset = False


### PR DESCRIPTION
Creating pull request for solution proposed by schacki #67, since it solves my problem as well.

Add "supports_over_clause = True". Without this in Django 3.0.13 gives:  "Exception Value: This backend does not support window expressions" error when attempting to use Window in annotation.

django-mssql-backend==2.8.1
pyodbc==4.0.30

Example:
```
queryseys.annotate(
       _order=Window(
              expression=DenseRank(),
              partition_by=[F('parent_id'), F('fluidtype')],
              order_by=F('date').desc(),
      ),
)
```